### PR TITLE
feat: added functionality to check undo and redo actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,8 @@
-
 /**
  * Override the initialize function for the _historyInit();
  */
-fabric.Canvas.prototype.initialize = (function(originalFn) {
-  return function(...args) {
+fabric.Canvas.prototype.initialize = (function (originalFn) {
+  return function (...args) {
     originalFn.call(this, ...args);
     this._historyInit();
     return this;
@@ -13,8 +12,8 @@ fabric.Canvas.prototype.initialize = (function(originalFn) {
 /**
  * Override the dispose function for the _historyDispose();
  */
-fabric.Canvas.prototype.dispose = (function(originalFn) {
-  return function(...args) {
+fabric.Canvas.prototype.dispose = (function (originalFn) {
+  return function (...args) {
     originalFn.call(this, ...args);
     this._historyDispose();
     return this;
@@ -26,19 +25,19 @@ fabric.Canvas.prototype.dispose = (function(originalFn) {
  */
 fabric.Canvas.prototype._historyNext = function () {
   return JSON.stringify(this.toDatalessJSON(this.extraProps));
-}
+};
 
 /**
  * Returns an object with fabricjs event mappings
  */
-fabric.Canvas.prototype._historyEvents = function() {
+fabric.Canvas.prototype._historyEvents = function () {
   return {
     'object:added': this._historySaveAction,
     'object:removed': this._historySaveAction,
     'object:modified': this._historySaveAction,
     'object:skewing': this._historySaveAction,
-  }
-}
+  };
+};
 
 /**
  * Initialization of the plugin
@@ -48,33 +47,31 @@ fabric.Canvas.prototype._historyInit = function () {
   this.historyRedo = [];
   this.extraProps = ['selectable', 'editable'];
   this.historyNextState = this._historyNext();
-  
+
   this.on(this._historyEvents());
-}
+};
 
 /**
  * Remove the custom event listeners
  */
 fabric.Canvas.prototype._historyDispose = function () {
-  this.off(this._historyEvents())
-}
+  this.off(this._historyEvents());
+};
 
 /**
  * It pushes the state of the canvas into history stack
  */
 fabric.Canvas.prototype._historySaveAction = function () {
-
-  if (this.historyProcessing)
-    return;
+  if (this.historyProcessing) return;
 
   const json = this.historyNextState;
   this.historyUndo.push(json);
   this.historyNextState = this._historyNext();
   this.fire('history:append', { json: json });
-}
+};
 
 /**
- * Undo to latest history. 
+ * Undo to latest history.
  * Pop the latest state of the history. Re-render.
  * Also, pushes into redo history.
  */
@@ -93,7 +90,7 @@ fabric.Canvas.prototype.undo = function (callback) {
   } else {
     this.historyProcessing = false;
   }
-}
+};
 
 /**
  * Redo to latest undo history.
@@ -112,42 +109,56 @@ fabric.Canvas.prototype.redo = function (callback) {
   } else {
     this.historyProcessing = false;
   }
-}
+};
 
-fabric.Canvas.prototype._loadHistory = function(history, event, callback) {
+fabric.Canvas.prototype._loadHistory = function (history, event, callback) {
   var that = this;
 
-  this.loadFromJSON(history, function() {
+  this.loadFromJSON(history, function () {
     that.renderAll();
     that.fire(event);
     that.historyProcessing = false;
 
-    if (callback && typeof callback === 'function')
-      callback();
+    if (callback && typeof callback === 'function') callback();
   });
-}
+};
 
 /**
  * Clear undo and redo history stacks
  */
-fabric.Canvas.prototype.clearHistory = function() {
+fabric.Canvas.prototype.clearHistory = function () {
   this.historyUndo = [];
   this.historyRedo = [];
   this.fire('history:clear');
-}
+};
 
 /**
  * On the history
  */
- fabric.Canvas.prototype.onHistory = function() {
+fabric.Canvas.prototype.onHistory = function () {
   this.historyProcessing = false;
 
   this._historySaveAction();
-}
+};
+
+/**
+ * Check if there are actions that can be undone
+ */
+
+fabric.Canvas.prototype.canUndo = function () {
+  return this.historyUndo.length > 0;
+};
+
+/**
+ * Check if there are actions that can be redone
+ */
+fabric.Canvas.prototype.canRedo = function () {
+  return this.historyRedo.length > 0;
+};
 
 /**
  * Off the history
  */
-fabric.Canvas.prototype.offHistory = function() {
+fabric.Canvas.prototype.offHistory = function () {
   this.historyProcessing = true;
-}
+};


### PR DESCRIPTION
This pull request adds the `canUndo` and `canRedo` functionality. The `canUndo` method returns true if there are actions that can be undone, and the `canRedo` method returns true if there are actions that can be redone.  Please review.

Cheers! 🎩

